### PR TITLE
Redução no limite para carregamento dos contatos.

### DIFF
--- a/backend/src/services/ContactServices/ListContactsService.ts
+++ b/backend/src/services/ContactServices/ListContactsService.ts
@@ -68,7 +68,7 @@ const ListContactsService = async ({
     };
   }
 
-  const limit = 5000;
+  const limit = 200;
   const offset = limit * (+pageNumber - 1);
 
   const { count, rows: contacts } = await Contact.findAndCountAll({


### PR DESCRIPTION
Redução no limite de carregamento de contatos de 5000 para 200 pois com o valor que está atualmente ao abrir a aba em questão, o sistema passa a consumir quase o tripo de memora RAM e CPU, assim causando uma sobrecarga tanto no front-end(client-side) quanto no back-end(server-side).

Consumo normal: (https://i.imgur.com/gJ451II.png) sistema consume em média na tela de ticket entre 70K à 100K de memoria e praticamente nada de CPU. Carregando a tela de contatos: (https://i.imgur.com/kOUae04.png) ao carregar, o consumo de CPU e REDE aumenta consideravelmente. Ao finalizar carregamento (https://i.imgur.com/SBnHiSd.png) o sistema já está consumindo de 1.25GB à 1.5GB de RAM.

Aqui o ambiente de trabalho são maquinas com processadores Intel i5 10ºGen, 8GB de RAM e 240GB SSD e com o limite acima de 200 reparamos que fica complicado de operar o Press-ticket após uma carga no contatos.