### PR TITLE
[FIX] Env Port variable

### DIFF
--- a/frontend/server.js
+++ b/frontend/server.js
@@ -9,4 +9,4 @@ app.get("/*", function (req, res) {
 	res.sendFile(path.join(__dirname, "build", "index.html"));
 });
 
-app.listen(process.env.PORT || 3333);
+app.listen(process.env.SERVER_PORT || 3333);


### PR DESCRIPTION
[CORRIGINDO] Variável da porta no arquivo ENV.

Nome da variável no arquivo em questão, se difere do arquivo .env, fazendo com que mesmo colocando a porta diferente no .env, não surja efeito na aplicação.