### PR TITLE
Corrigir erro 'unknown column contact.name' na pesquisa de ticket

### DIFF
--- a/backend/src/services/TicketServices/ListTicketsService.ts
+++ b/backend/src/services/TicketServices/ListTicketsService.ts
@@ -148,6 +148,7 @@ const ListTicketsService = async ({
   settingCreated = settingCreated === "enabled" ? "createdAt" : "updatedAt";
 
   const { count, rows: tickets } = await Ticket.findAndCountAll({
+    subQuery: false, // THIS FIXES THE SEARCH but 'limit' may not work properly
     where: whereCondition,
     include: includeCondition,
     distinct: true,


### PR DESCRIPTION
Corrigir erro 'unknown column contact.name' na pesquisa de ticket/mensagem/contato

Sequelize tem um bug ativo, estão tentando corrigir, que quando utilizamos limit, include, offset, juntos, e no include há tabelas relacionadas, dá erro de unknown column, por isso o fix temporário é desativar o subQuery, referencias:  https://github.com/sequelize/sequelize/issues/9166 https://stackoverflow.com/questions/23312868/unknown-column-error-in-sequelize-when-using-limit-and-include-options https://stackoverflow.com/questions/59453957/unknown-column-while-executing-where-conditions-sequelize-subquery-field

@rtenorioh se voce conseguir corrigir esse problema sem precisar desativar a subquery de algum modo, talvez seja uma correção melhor. Mas essa é a única pro momento. Não percebi nenhum erro de retornar tickets errados nem nada do tipo então parece q tá safe nesse caso.